### PR TITLE
add IQSS at Harvard

### DIFF
--- a/data/github/iqss.yaml
+++ b/data/github/iqss.yaml
@@ -1,0 +1,3 @@
+org: harvard.edu
+name: IQSS
+


### PR DESCRIPTION
Hi @szabgab I remember you from Perl days. Not in person but blogs or whatever. This seems like an interesting project!

This pull request is about adding @IQSS to your list of GitHub orgs at Harvard but there's a lot more where that came from! Since 2017 I've been maintaining a list of open source projects at Harvard over at https://github.com/IQSS/open-source-at-harvard

Every so often, I hit the GitHub API and pull out similar information for each project that you are (stars, etc.) and publish it as a dataset at https://doi.org/10.7910/DVN/TJCLKP

Here's a preview of the IQSS repos:

![Screenshot 2023-03-25 at 17-19-41 IQSS](https://user-images.githubusercontent.com/21006/227742610-b54b59b8-bc79-4137-a7c9-5e115efd88aa.png)
